### PR TITLE
Add merge_unique function

### DIFF
--- a/SLib.gd
+++ b/SLib.gd
@@ -202,3 +202,18 @@ func FullPath(Path: String):
 			path = path.erase(0,6)
 			path = OS.get_executable_path().get_base_dir().path_join(path)
 		return path
+
+## Merges two arrays and returns a new array with unique values.
+## [br][br]
+## Example:
+## [codeblock]
+## var myarray1: Array = [1,2,3,4]
+## var myarray2: Array = [3,4,5,6]
+## var merged_array: Array = SLib.merge_unique(myarray1,myarray2)
+## [/codeblock]
+func merge_unique(array1: Array, array2: Array) -> Array:
+	var merged_array = array1.duplicate(true)
+	for item in array2:
+		if not merged_array.has(item):
+			merged_array.append(item)
+	return merged_array


### PR DESCRIPTION
Adds a basic function that I was missing from the array class. 
It combines two arrays and only adds items from the second array to the first array if the first array does not already contain them

If the first array contains duplicate values to begin with, then the resulting array will not contain only unique values. Maybe we need to do adjustments there or describe this caveat in the description.

I am currently using this function here: https://github.com/Khaligufzel/CataX/blob/688463d112b128e7abc5ea09c56f1753ee18d9ca/Scripts/gamedata.gd#L531